### PR TITLE
Implement nanoconfig support

### DIFF
--- a/_nanomsg_ctypes/__init__.py
+++ b/_nanomsg_ctypes/__init__.py
@@ -237,3 +237,25 @@ nn_device.__doc__ = "start a device"
 nn_term = _nn_term
 nn_term.__doc__ = "notify all sockets about process termination"
 
+try:
+    if 'win' in sys.platform:
+        _nclib = ctypes.windll.nanoconfig
+    else:
+        _nclib = ctypes.cdll.LoadLibrary('libnanoconfig.so')
+except OSError:
+    pass # No nanoconfig, sorry
+else:
+    # int nc_configure (int s, const char *addr)
+    nc_configure = _functype(ctypes.c_int, ctypes.c_int, ctypes.c_char_p)(
+        ('nc_configure', _nclib), ((1, 's'), (1, 'addr')))
+    nc_configure.__doc__ = "configure socket using nanoconfig"
+
+    # void nc_close(int s);
+    nc_close = _functype(None, ctypes.c_int)(
+        ('nc_close', _nclib), ((1, 's'),))
+    nc_close.__doc__ = "close an SP socket configured with nn_configure"
+
+    # void nc_term();
+    nc_term = _functype(None)(
+        ('nc_term', _nclib), ())
+    nc_term.__doc__ = "shutdown nanoconfig worker thread"

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ from __future__ import division, absolute_import, print_function,\
  unicode_literals
 
 import os
+import sys
 try:
     from setuptools import setup
 except ImportError:
@@ -36,11 +37,25 @@ class skippable_build_ext(build_ext):
             print("=" * 79)
             print()
 
-
-cpy_extension = Extension(str('_nanomsg_cpy'),
-                    sources=[str('_nanomsg_cpy/wrapper.c')],
-                    libraries=[str('nanomsg')],
-                    )
+try:
+    import ctypes
+    if 'win' in sys.platform:
+        _lib = ctypes.windll.nanoconfig
+    else:
+        _lib = ctypes.cdll.LoadLibrary('libnanoconfig.so')
+except OSError:
+    # Building without nanoconfig
+    cpy_extension = Extension(str('_nanomsg_cpy'),
+                        sources=[str('_nanomsg_cpy/wrapper.c')],
+                        libraries=[str('nanomsg')],
+                        )
+else:
+    # Building with nanoconfig
+    cpy_extension = Extension(str('_nanomsg_cpy'),
+                        define_macros=[('WITH_NANOCONFIG', '1')],
+                        sources=[str('_nanomsg_cpy/wrapper.c')],
+                        libraries=[str('nanomsg'), str('nanoconfig')],
+                        )
 
 
 setup(
@@ -67,5 +82,5 @@ setup(
     url='https://github.com/tonysimpson/nanomsg-python',
     keywords=['nanomsg', 'driver'],
     license='MIT',
-    test_suite="tests", 
+    test_suite="tests",
 )


### PR DESCRIPTION
Hi,

As discussed in nanomsg mailing list, it's better to support [nanoconfig](http://github.com/nanomsg/nanoconfig) directly by the nanomsg bindings instead of creating separate. The pull request adds just that.

The support of nanoconfig is optional, and is silently disabled if the library is not installed at build time (for the C bindings) or at runtime (for ctypes bindings).

The patch is submitted under MIT license.
