### PR TITLE
Adding osx support for nanoconfig and changing platform check

### DIFF
--- a/_nanomsg_ctypes/__init__.py
+++ b/_nanomsg_ctypes/__init__.py
@@ -8,7 +8,7 @@ import sys
 if sys.platform in ('win32', 'cygwin'):
     _functype = ctypes.WINFUNCTYPE
     _lib = ctypes.windll.nanomsg
-elif sys.platform in ('darwin'):
+elif sys.platform == 'darwin':
     _functype = ctypes.CFUNCTYPE
     _lib = ctypes.cdll.LoadLibrary('libnanomsg.dylib')
 else:

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,8 @@ try:
     import ctypes
     if sys.platform in ('win32', 'cygwin'):
         _lib = ctypes.windll.nanoconfig
+    elif sys.platform == 'darwin':
+        _lib = ctypes.cdll.LoadLibrary('libnanoconfig.dylib')
     else:
         _lib = ctypes.cdll.LoadLibrary('libnanoconfig.so')
 except OSError:


### PR DESCRIPTION
Adding check for osx when building nanoconfig.
Changing platform check from 'in' to '=='.