### PR TITLE
Improvements to _nanomsg_ctypes

### DIFF
--- a/_nanomsg_ctypes/__init__.py
+++ b/_nanomsg_ctypes/__init__.py
@@ -2,18 +2,19 @@ from __future__ import division, absolute_import, print_function,\
  unicode_literals
 
 import ctypes
+import os
 import platform
 import sys
 
 if sys.platform in ('win32', 'cygwin'):
     _functype = ctypes.WINFUNCTYPE
-    _lib = ctypes.windll.nanomsg
+    _lib = ctypes.windll.LoadLibrary(os.environ.get('NN_CTYPES_LIB_PATH', 'nanomsg'))
 elif sys.platform == 'darwin':
     _functype = ctypes.CFUNCTYPE
-    _lib = ctypes.cdll.LoadLibrary('libnanomsg.dylib')
+    _lib = ctypes.cdll.LoadLibrary(os.environ.get('NN_CTYPES_LIB_PATH', 'libnanomsg.dylib'))
 else:
     _functype = ctypes.CFUNCTYPE
-    _lib = ctypes.cdll.LoadLibrary('libnanomsg.so')
+    _lib = ctypes.cdll.LoadLibrary(os.environ.get('NN_CTYPES_LIB_PATH', 'libnanomsg.so'))
 
 
 def _c_func_wrapper_factory(cdecl_text):
@@ -272,11 +273,11 @@ nn_term.__doc__ = "notify all sockets about process termination"
 
 try:
     if sys.platform in ('win32', 'cygwin'):
-        _nclib = ctypes.windll.nanoconfig
+        _nclib = ctypes.windll.LoadLibrary(os.environ.get('NN_CTYPES_NCLIB_PATH', 'nanoconfig'))
     elif sys.platform == 'darwin':
-        _nclib = ctypes.cdll.LoadLibrary('libnanoconfig.dylib')
+        _nclib = ctypes.cdll.LoadLibrary(os.environ.get('NN_CTYPES_NCLIB_PATH', 'libnanoconfig.dylib'))
     else:
-        _nclib = ctypes.cdll.LoadLibrary('libnanoconfig.so')
+        _nclib = ctypes.cdll.LoadLibrary(os.environ.get('NN_CTYPES_NCLIB_PATH', 'libnanoconfig.so'))
 except OSError:
     pass # No nanoconfig, sorry
 else:

--- a/_nanomsg_ctypes/__init__.py
+++ b/_nanomsg_ctypes/__init__.py
@@ -273,6 +273,8 @@ nn_term.__doc__ = "notify all sockets about process termination"
 try:
     if sys.platform in ('win32', 'cygwin'):
         _nclib = ctypes.windll.nanoconfig
+    elif sys.platform == 'darwin':
+        _nclib = ctypes.cdll.LoadLibrary('libnanoconfig.dylib')
     else:
         _nclib = ctypes.cdll.LoadLibrary('libnanoconfig.so')
 except OSError:


### PR DESCRIPTION
1. In commit 66a1d1d6ecf12c48b2d9699216eb9cf42eb1a241, OS X support was added, but did not include nanoconfig. This will try to load libnanoconfig.dylib instead of libnanoconfig.so on OS X.

2. Added a way to provide the path from which we load the libraries, using the environment variables `NN_CTYPES_LIB_PATH` and `NN_CTYPES_NCLIB_PATH`.