### PR TITLE
Socket options should be integer, not long

### DIFF
--- a/nanomsg/__init__.py
+++ b/nanomsg/__init__.py
@@ -159,7 +159,7 @@ class Socket(object):
 
     """
 
-    _INT_PACKER = _Struct(str('l'))
+    _INT_PACKER = _Struct(str('i'))
 
     class _Endpoint(object):
         def __init__(self, socket, endpoint_id, address):


### PR DESCRIPTION
Using anaconda3 Python 3.7 on OSX at least, the 'l' format using pack produces a 64bit result. The nanomsg C API calls``nn_[set|get]sockopt()`` expect a pointer to an int according to the documentation.

```
Python 3.7.0 (default, Jun 28 2018, 07:39:16)
[Clang 4.0.1 (tags/RELEASE_401/final)] :: Anaconda, Inc. on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from struct import *
>>> pack('l', 1)
b'\x01\x00\x00\x00\x00\x00\x00\x00'
>>> pack('i', 1)
b'\x01\x00\x00\x00'
>>>
```

We can verify that ``int`` is in fact 4 bytes using the default clang compilter on OSX:

```
#include <stdio.h>
#include <stdlib.h>

int main()
{
  printf("%lu\n", sizeof(int));
  return EXIT_SUCCESS;
}
```

```
$ gcc -o test test.c
$ ./test
4
```