### PR TITLE
Fix ctype int for _INT_PACKER and cleanup travisci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: required
+
 language: python
 python:
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,13 @@ python:
   - "3.6"
   - "3.7"
 
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y software-properties-common
+  - sudo add-apt-repository -y -u ppa:ubuntu-toolchain-r/test
+  - sudo apt-get -qq update
+  - sudo apt-get install -y --allow-unauthenticated build-essential cmake
+
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 # Build steps taken from
 # https://github.com/nanomsg/nanomsg#build-it-with-cmake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: python
 python:
-  - "3.2"
-  - "3.3"
-  - "3.4"
   - "2.7"
-  - "2.6"
+  - "3.5"
+  - "3.6"
+  - "3.7"
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 # Build steps taken from
@@ -12,14 +11,14 @@ python:
 install:
   - git clone --quiet --depth=100 "https://github.com/nanomsg/nanomsg.git" ~/builds/nanomsg
       && pushd ~/builds/nanomsg
-      && mkdir build
-      && cd build
-      && cmake ..
-      && cmake --build .
-      && ctest -C Debug .
-      && sudo cmake --build . --target install
-      && sudo ldconfig
-      && popd
+  - export TRAVIS_TAG=$(cat .version)
+  - git checkout -b "${TRAVIS_TAG}"
+  - mkdir build && cd build
+  - cmake ..
+  - cmake --build .
+  - ctest -C Debug .
+  - sudo cmake --build . --target install
+  - sudo ldconfig && popd
 
 # command to run tests, e.g. python setup.py test
 script: LD_LIBRARY_PATH=/lib:/usr/lib:/usr/local/lib python setup.py test

--- a/nanomsg/__init__.py
+++ b/nanomsg/__init__.py
@@ -159,7 +159,7 @@ class Socket(object):
 
     """
 
-    _INT_PACKER = _Struct(str('l'))
+    _INT_PACKER = _Struct(str('i'))
 
     class _Endpoint(object):
         def __init__(self, socket, endpoint_id, address):


### PR DESCRIPTION
Hi, I guess the nanomsg nng/legacy thing is still an issue (depending on individual needs) so this binding is definitely *not* obsolete, eg, nanoservice uses this binding and I need to use nanoservice, so I ended up having to fix the failing tests, which turned out to be a small bug in the size of the integer passed to get_int interface.  This is basically that fix plus minimal .travis.yml fixes to make it build again in the default travis xenial env.